### PR TITLE
\chi

### DIFF
--- a/lec_19.tex
+++ b/lec_19.tex
@@ -25,11 +25,11 @@ Im Folgenden wollen wir Funktionen, die \fue gleich sind, miteinander identifizi
 \begin{definition}\label{stufen_mit_integral}
   Eine Stufenfunktion ist eine Funktion der Form
   \begin{equation*}
-    \varphi=\sum_{j=1}^{n}c_j \characteristicfunction;{Q},
+    \varphi=\sum_{j=1}^{n}c_j \chi_{Q_j},
   \end{equation*}
   \( Q_j=I_{j,1}\times\dotsb I_{j,n} \), \( I_{j,i} \) \emph{beschränkte} Intervalle.
   \begin{equation*}
-    \characteristicfunction{Q}{x}=\begin{cases}
+    \chi_{Q}{x}=\begin{cases}
       1&x\in Q\\
       0& x\not\in Q
     \end{cases}
@@ -54,7 +54,7 @@ Im Folgenden wollen wir Funktionen, die \fue gleich sind, miteinander identifizi
   \begin{subproof}
     \Obda \( I=\interval{0}{1} \) (den \( \set{0,1} \) ist Nullmenge). Angenommen, \texists  \( I_j \) offen \sd \( I\subset \bigcup I_j \) und \( \sum_{j=1}^{\infty}\abs{I_j}<\varepsilon \) mit \( 0<\varepsilon<1 \). \( \interval{0}{1} \) ist kompakt \timplies \texists \( i_1,\dotsc,i_k \) \sd
     \begin{equation*}
-      \interval{0}{1}\subset \bigcup_{j=1}^k \mathcal{U}_{i_j}\implies 1=\Integrate{0}{1}{x}\explain{\sum_{j=1}^{k}\characteristicfunction{I_{i_j}}{x}\geq 1\ (\text{\diffcourse{1}})}{\leq}\Integrate{\sum_{j=1}^{k}\characteristicfunction{I_{i_j}}{x}}{x}\explain{\text{\diffcourse{1}}}{=}\sum_{j=1}^{k}\Integrate{\characteristicfunction{I_{i_j}{x}}}{x}<\varepsilon\ \contra.
+      \interval{0}{1}\subset \bigcup_{j=1}^k \mathcal{U}_{i_j}\implies 1=\Integrate{0}{1}{x}\explain{\sum_{j=1}^{k}\chi_{I_{i_j}}{x}\geq 1\ (\text{\diffcourse{1}})}{\leq}\Integrate{\sum_{j=1}^{k}\chi_{I_{i_j}}{x}}{x}\explain{\text{\diffcourse{1}}}{=}\sum_{j=1}^{k}\Integrate{\chi_{I_{i_j}{x}}}{x}<\varepsilon\ \contra.
     \end{equation*}    
   \end{subproof}
   \end{proofdescription}
@@ -90,7 +90,7 @@ Im Folgenden wollen wir Funktionen, die \fue gleich sind, miteinander identifizi
     \end{equation*}
     Dies gilt dann
     \begin{equation*}
-      \frac{A}{\varepsilon}\sum_{k=1}^{m}\sum_{j=1}^{l_k}\volume{Q_{k,j}}\explain{\text{\Def }\mathcal{U}_{\varepsilon,k}}{\leq}\braceannotate{\Integrate{\varphi_k \characteristicfunction{\mathcal{U}_{\varepsilon,k}}}{x}}{\Integrate{\varphi_k}{x,\mathcal{U}_{\varepsilon,k}}}\leq \Integrate{\varphi_m}{x}\leq A.
+      \frac{A}{\varepsilon}\sum_{k=1}^{m}\sum_{j=1}^{l_k}\volume{Q_{k,j}}\explain{\text{\Def }\mathcal{U}_{\varepsilon,k}}{\leq}\braceannotate{\Integrate{\varphi_k \chi_{\mathcal{U}_{\varepsilon,k}}}{x}}{\Integrate{\varphi_k}{x,\mathcal{U}_{\varepsilon,k}}}\leq \Integrate{\varphi_m}{x}\leq A.
     \end{equation*}
   \end{proofdescription}
   
@@ -245,10 +245,10 @@ und für jedes feste \( k \) gilt
 \end{satz}
 \begin{bemerkung*}
   Die Voraussetzung ist wichtig:\\
-  Betrachte \( f_k=-\characteristicfunction.{\ointerval{-\infty}{0}}{}+\characteristicfunction.{\ointerval{0}{k}}{} \). Dann ist \( f=\sgn;\not\in \stufenfunktionen[2] \), \( \sgn{x}=\begin{cases}
+  Betrachte \( f_k=-\chi_{\ointerval{-\infty}{0}}+\chi_{\ointerval{0}{k}} \). Dann ist \( f=\sgn;\not\in \stufenfunktionen[2] \), \( \sgn{x}=\begin{cases}
     1&x>0\\ 0&x=0\\ -1&x<0.
   \end{cases} \)
-  Betrachte \( f_k=-\characteristicfunction-{\ointerval{k}{\infty}}{} \). Dann ist \( f=0\in \stufenfunktionen[2] \) aber \eqref{eq:beppo-levi} trifft nicht zu.
+  Betrachte \( f_k=-\chi_{\ointerval{k}{\infty}} \). Dann ist \( f=0\in \stufenfunktionen[2] \) aber \eqref{eq:beppo-levi} trifft nicht zu.
 \end{bemerkung*}
 \begin{proof}[Beweis von \ref{beppo-levi}]
   Für \( k\geq k_0 \) gilt \( \int f_k>-\infty \) (wegen der Monotonie). Sei \( k\geq k_0 \). Schreibe \( f_k=g_k-h_k \), \( g_k,h_k\in \stufenfunktionen[1] \). Dann ist \( \int h_k<\infty \) \timplies \texists \( \varphi_k\in \stufenfunktionen[0] \) \sd \( \varphi_k\leq h_k \) und \( \Integrate{h_k-\varphi_k}{x}<2^{-k} \)

--- a/lec_20.tex
+++ b/lec_20.tex
@@ -41,7 +41,7 @@ Ein Maß heißt \emph{vollständig}, wenn gilt: Ist \( N\in \Sigma \) mit \( \mu
   \end{itemize}
 \end{bemerkung*}
 \begin{satz}
-   Setze \( \mathcal{M}\definedas \Set{E\subset \reals^n|\characteristicfunction;{E}\in \stetigefunktionen[2]} \) und \( \mu(E)\definedas \Integrate{\characteristicfunction;{E}}{x} \).Dann ist \( (\reals^n,\mathcal{M},\mu) \) ein \( \varsigma \)-endlicher, vollständiger Maßraum.
+   Setze \( \mathcal{M}\definedas \Set{E\subset \reals^n|\chi_E\in \stetigefunktionen[2]} \) und \( \mu(E)\definedas \Integrate{\chi_E}{x} \).Dann ist \( (\reals^n,\mathcal{M},\mu) \) ein \( \varsigma \)-endlicher, vollständiger Maßraum.
 \end{satz}
 \begin{proof}
   Das folgt direkt aus dem verallgemeinerten Satz von Beppo-Levi. Details als Hausaufgabe.
@@ -78,7 +78,7 @@ Ein Maß heißt \emph{vollständig}, wenn gilt: Ist \( N\in \Sigma \) mit \( \mu
 \begin{folgerung}
   \begin{enumerate}
     \item\label{lebesgue_integrable_funktionen_norm} \( \explicitnorm{\lebesgueintegrablefunctions}{f}\definedas \Integrate{\abs{f}}{x} \) definiert eine Norm auf \( \lebesgueintegrablefunctions \).
-    \item\label{nullmengen_funzen_mit_sigma_algebra} \( N\subset \reals^n \) ist Nullmenge \tiff \( N\in \mathcal{M} \) und  (\s \ref{}) \( \mu(N)=\Integrate{\characteristicfunction;{N}}{x}=0 \).
+    \item\label{nullmengen_funzen_mit_sigma_algebra} \( N\subset \reals^n \) ist Nullmenge \tiff \( N\in \mathcal{M} \) und  (\s \ref{}) \( \mu(N)=\Integrate{\chi_N}{x}=0 \).
   \end{enumerate}
 \end{folgerung}
 \begin{proof}
@@ -95,7 +95,7 @@ Ein Maß heißt \emph{vollständig}, wenn gilt: Ist \( N\in \Sigma \) mit \( \mu
       \item[\rueck] klar 
       \item[\hin] \( f=f_1-f_2 \) und \emph{beide} \( \int f_1<\infty \) \emph{und} \( \int f_2<\infty \). 
     \end{proofdescription}
-    \item[\ref{nullmengen_funzen_mit_sigma_algebra}] Zu zeigen ist: \( \characteristicfunction;{N}=0\iff \Integrate{\characteristicfunction;{N}}{x}=0 \).
+    \item[\ref{nullmengen_funzen_mit_sigma_algebra}] Zu zeigen ist: \( \chi_N=0\iff \Integrate{\chi_N}{x}=0 \).
     \begin{proofdescription}
       \item[\hin] \checkmark\\
       \item[\rueck] wegen \ref{lebesgue_integrable_funktionen_norm} \checkmark. 
@@ -128,7 +128,7 @@ Ein Maß heißt \emph{vollständig}, wenn gilt: Ist \( N\in \Sigma \) mit \( \mu
   Sei \( \p*{f_k}_k\subset \lebesgueintegrablefunctions \), \( f_k\goesto f \). Gibt es \( g\in \lebesgueintegrablefunctions \), \sd \( \abs{g_k}\leq g \qquad \forall k  \), so ist \( f\in \lebesgueintegrablefunctions \) und \( \Integrate{f_k}{x}\goesto \Integrate{f}{x} \)
 \end{satz}
 \begin{bemerkung*}
-  Voraussetzung \( \abs{f_k}\leq g \) ist wichtig, wie folgendes Anti-Beispiel zeigt: \( f_k=k \characteristicfunction;{\ointerval{0}{\frac{1}{3}}} \), \( f_k\goesto f=0 \), aber \( \int f_k=1\quad \forall k \).
+  Voraussetzung \( \abs{f_k}\leq g \) ist wichtig, wie folgendes Anti-Beispiel zeigt: \( f_k=k \chi_{\ointerval{0}{\frac{1}{3}}} \), \( f_k\goesto f=0 \), aber \( \int f_k=1\quad \forall k \).
 \end{bemerkung*}
 \begin{proof}[\ref{majorisierte_konvergenz}]
   Wir wenden Faton an au \( \p*{g-f_k}_k \) und \( \p*{g+f_k}_k \) \timplies \( g-f,g+f\in \lebesgueintegrablefunctions \) und 
@@ -148,7 +148,7 @@ Ein Maß heißt \emph{vollständig}, wenn gilt: Ist \( N\in \Sigma \) mit \( \mu
   \end{equation*}
   also
   \begin{equation*}
-    \lim_{n \goesto \infty}\Integrate{\braceannotate{f_n(x)}{\characteristicfunction{\interval{0}{1}}{x}\p*{n\Sin{\frac{x}{n}}}^n}}{x}.
+    \lim_{n \goesto \infty}\Integrate{\braceannotate{f_n(x)}{\chi_{\interval{0}{1}}{x}\p*{n\Sin{\frac{x}{n}}}^n}}{x}.
   \end{equation*}
   Für \( x\in \interval{0}{1} \) ist
   \begin{equation*}
@@ -290,7 +290,7 @@ Mann kann \(\lebesgueintegrablefunctions(\interval{a}{b},\reals)\) auch durch Ve
         in \(\lebesgueintegrablefunctions\) (denn ist etwa \(x<z\), so ist \(\Med{x}{y}{z}=\Max{x,\Min{y,z}}\)).
         Wegen \(\abs{f_k}<g\forall k\) folgt die Behauptung aus \ref{theoLebesgueMajKonv}.
         \item Wähle \(A_1\subset A_2\subset\ldots,\ \mu(A_j)<\infty,\ \evaluateat{f}{\reals^n\setminus \bigcup_j A_j}=0\).
-        \(f_k\definedas \Min*{f,k\characteristicfunction;{A_k}}\in \lebesgueintegrablefunctions\) (wegen (ii) \(f_k\goesupto f\). Behauptung folgt mit \ref{theoBeppoLevi}).
+        \(f_k\definedas \Min*{f,k\chi_{A_k}}\in \lebesgueintegrablefunctions\) (wegen (ii) \(f_k\goesupto f\). Behauptung folgt mit \ref{theoBeppoLevi}).
     \end{enumerate}
 \end{proof}
 
@@ -299,12 +299,12 @@ Mann kann \(\lebesgueintegrablefunctions(\interval{a}{b},\reals)\) auch durch Ve
 
 Es gibt Funktionen, die sind Lebesgue-integrierbar, aber nicht Riemann-integrierbar.
 \begin{beispiel}
-    \(\characteristicfunction;{\rationals}\)\\
+    \(\chi_{\rationals}\)\\
     Riemann-Integration:\\
         Alle Obersummen sind 1, alle Untersummen 0. Nur Funktionen mit endlich vielen Sprungstellen / Unendlichkeiten sind Riemann-integrierbar.
 
     Lebesgue-Integration:\\
-        \( \rationals \) = Nullmenge in \( \reals \)\timplies\(\int\characteristicfunction;{\rationals}=0\). Es sind abzählbar unendlich viele Sprung- / Unendlichkeitsstellen erlaubt.
+        \( \rationals \) = Nullmenge in \( \reals \)\timplies\(\int\chi_{\rationals}=0\). Es sind abzählbar unendlich viele Sprung- / Unendlichkeitsstellen erlaubt.
 \end{beispiel}
 
 \begin{erinnerung*}
@@ -334,7 +334,7 @@ Wir zeigen stattdessen:
     \label{theoRegelFkt} % 6.25
     Eine Regelfunktion \(f\) auf \(\interval{a}{b}\) ist über \(\interval{a}{b}\) Lebesgue-integrierbar und das Regel-Integral ist gleich dem Lebesgue-Integral.
     \begin{equation*}
-        \underbrace{\Integrate{f}{x,\interval{a}{b}}}_{=\int{\characteristicfunction;{\interval{a}{b}}f{x}}}=\Integrate{f(x)}{x,a,b}
+        \underbrace{\Integrate{f}{x,\interval{a}{b}}}_{=\int{\chi_{\interval{a}{b}}f{x}}}=\Integrate{f(x)}{x,a,b}
     \end{equation*}
 \end{satz}
 


### PR DESCRIPTION
Die charakteristische Funktion wird einfach mit \chi bezeichnet, die Definition von \characteristicfunction war also etwas überflüssig. Habe glaube alle ersetzt.
Alle weiteren Fehler scheinst du schon selbst gefunden zu haben